### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,7 @@
 name: 🚀 Build & Push Docker Image
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/wificard-docker/security/code-scanning/1](https://github.com/Jackie264/wificard-docker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow involves checking out code and pushing a Docker image, the minimal required permissions are `contents: read` and `packages: write`. The `contents: read` permission allows the workflow to access the repository's contents, and `packages: write` is necessary for pushing the Docker image to a registry.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply these permissions globally to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
